### PR TITLE
Correct ServerURL and Naming

### DIFF
--- a/cloudflare-doh-filter-malware.mobileconfig
+++ b/cloudflare-doh-filter-malware.mobileconfig
@@ -17,12 +17,12 @@
 					<string>2606:4700:4700::1002</string>
 				</array>
 				<key>ServerURL</key>
-				<string>https://cloudflare-dns.com/dns-query</string>
+				<string>https://security.cloudflare-dns.com/dns-query</string>
 			</dict>
 			<key>PayloadDescription</key>
-			<string>Configures your device to use Cloudflare DNS over HTTPS.</string>
+			<string>Configures your device to use Cloudflare DNS over HTTPS with malware blocking.</string>
 			<key>PayloadDisplayName</key>
-			<string>Cloudflare DNS over HTTPS</string>
+			<string>Cloudflare DNS over HTTPS with malware blocking</string>
 			<key>PayloadIdentifier</key>
 			<string>com.adamheckler.cloudflare-doh-filter-malware.73A844E4-F911-4E94-9F4A-772CA8486969</string>
 			<key>PayloadType</key>
@@ -36,9 +36,9 @@
 		</dict>
 	</array>
 	<key>PayloadDescription</key>
-	<string>Configures your device to use Cloudflare DNS over HTTPS.</string>
+	<string>Configures your device to use Cloudflare DNS over HTTPS with malware blocking.</string>
 	<key>PayloadDisplayName</key>
-	<string>Cloudflare DNS over HTTPS</string>
+	<string>Cloudflare DNS over HTTPS with malware blocking</string>
 	<key>PayloadIdentifier</key>
 	<string>com.adamheckler.cloudflare-doh-filter-malware</string>
 	<key>PayloadRemovalDisallowed</key>

--- a/cloudflare-doh-filter-malware.mobileconfig
+++ b/cloudflare-doh-filter-malware.mobileconfig
@@ -22,7 +22,7 @@
 			<key>PayloadDescription</key>
 			<string>Configures your device to use Cloudflare DNS over HTTPS with malware blocking.</string>
 			<key>PayloadDisplayName</key>
-			<string>Cloudflare DoH Malware</string>
+			<string>Cloudflare DoH Malware Block</string>
 			<key>PayloadIdentifier</key>
 			<string>com.adamheckler.cloudflare-doh-filter-malware.73A844E4-F911-4E94-9F4A-772CA8486969</string>
 			<key>PayloadType</key>
@@ -38,7 +38,7 @@
 	<key>PayloadDescription</key>
 	<string>Configures your device to use Cloudflare DNS over HTTPS with malware blocking.</string>
 	<key>PayloadDisplayName</key>
-	<string>Cloudflare DoH Malware</string>
+	<string>Cloudflare DoH Malware Block</string>
 	<key>PayloadIdentifier</key>
 	<string>com.adamheckler.cloudflare-doh-filter-malware</string>
 	<key>PayloadRemovalDisallowed</key>

--- a/cloudflare-doh-filter-malware.mobileconfig
+++ b/cloudflare-doh-filter-malware.mobileconfig
@@ -22,7 +22,7 @@
 			<key>PayloadDescription</key>
 			<string>Configures your device to use Cloudflare DNS over HTTPS with malware blocking.</string>
 			<key>PayloadDisplayName</key>
-			<string>Cloudflare DNS over HTTPS with malware blocking</string>
+			<string>Cloudflare DoH Malware</string>
 			<key>PayloadIdentifier</key>
 			<string>com.adamheckler.cloudflare-doh-filter-malware.73A844E4-F911-4E94-9F4A-772CA8486969</string>
 			<key>PayloadType</key>
@@ -38,7 +38,7 @@
 	<key>PayloadDescription</key>
 	<string>Configures your device to use Cloudflare DNS over HTTPS with malware blocking.</string>
 	<key>PayloadDisplayName</key>
-	<string>Cloudflare DNS over HTTPS with malware blocking</string>
+	<string>Cloudflare DoH Malware</string>
 	<key>PayloadIdentifier</key>
 	<string>com.adamheckler.cloudflare-doh-filter-malware</string>
 	<key>PayloadRemovalDisallowed</key>


### PR DESCRIPTION
Now using the correct ServerURL for the malware blocking DNS per https://developers.cloudflare.com/1.1.1.1/1.1.1.1-for-families/setup-instructions/dns-over-https and also adjusted naming to distinguish from the other CF profiles.